### PR TITLE
Fixed bug: Clearing when there's no current terminal background no lo…

### DIFF
--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -76,7 +76,10 @@ def main(argv=None):
         if event_exists:
             slideshow.stop(event_name)
         if not options.wallpaper:
-            scripter.clear_terminal()
+            try:
+                scripter.clear_terminal()
+            except KeyError:
+                print("There's no current background to clear.")
         return
 
     if is_slideshow and options.id <= 0 and size > 1:


### PR DESCRIPTION
Currently, if the user tries to input "pokemon -c" when there is no current terminal background, a KeyError is caused. 
![Screenshot 2024-04-01 182804](https://github.com/CullenLYe/Pokemon-Terminal/assets/59585764/4ac3e49c-1a28-40f6-9aed-d62b089e1c98)

I added a simple try/except block to print out "There's no background to clear." to account for this.
![Screenshot 2024-04-01 195213](https://github.com/CullenLYe/Pokemon-Terminal/assets/59585764/5f37dfa2-8fec-4bc2-83bf-31edad89eda8)